### PR TITLE
Fix: Handle undefined result in get_bot_response function

### DIFF
--- a/chatbot.py
+++ b/chatbot.py
@@ -56,6 +56,7 @@ def class_prediction(sentence, model):
 def get_bot_response(ints, intents):
     tag = ints[0]['intent']
     intents_list = intents['intents']
+    result = "I'm sorry, I don't understand that."  # Default response
     for intent in intents_list:
         if intent['tag'] == tag:
             result = random.choice(intent['responses'])


### PR DESCRIPTION
- Added a default response to initialize `result` in `get_bot_response`.
- Ensures the bot provides a fallback response if no matching intent tag is found.
- Prevents `UnboundLocalError` when `result` is accessed without being assigned.